### PR TITLE
Fixed node@0.8 and Travis CI

### DIFF
--- a/lib/resolve-link.js
+++ b/lib/resolve-link.js
@@ -8,7 +8,8 @@ function resolveLink(srcUrl, targetUrl) {
   var srcUrlObj = url.parse(srcUrl);
 
   // If there isn't a protocol
-  if (srcUrlObj.protocol === null) {
+  // DEV: `node@0.8` has this as `undefined`, `node@0.10` has this as `null`
+  if (!srcUrlObj.protocol) {
     // With no protocol, we have everything in pathname. Add on `//` and force treatment of `host`
     var tmpSrcUrl = '//' + srcUrl;
     var tmpSrcUrlObj = url.parse(tmpSrcUrl, null, true);
@@ -26,12 +27,14 @@ function resolveLink(srcUrl, targetUrl) {
   srcUrlObj.pathname = srcUrlObj.pathname || '/';
 
   // If we still have no protocol
-  if (srcUrlObj.protocol === null) {
+  // DEV: `node@0.8` has this as `undefined`, `node@0.10` has this as `null`
+  if (!srcUrlObj.protocol) {
     // Parse our targetUrl
     var targetUrlObj = url.parse(targetUrl);
 
     // If there is a hostname
-    if (srcUrlObj.hostname !== null) {
+    // DEV: `node@0.8` has this as `undefined`, `node@0.10` has this as `null`
+    if (srcUrlObj.hostname) {
       // If the hostname is the same as our original, add on a protocol
       if (srcUrlObj.hostname === targetUrlObj.hostname) {
         srcUrlObj.protocol = targetUrlObj.protocol;


### PR DESCRIPTION
We landed our initial release without waiting for Travis CI to catch up. It turns out that we were having inconsistent behaviors between `node@0.8` and `node@0.10` which lead to `node@0.8` failing. In this PR:
- Added fixes for `node@0.8`

/cc @cmuir 
